### PR TITLE
Update nex.md

### DIFF
--- a/bosses/nex.md
+++ b/bosses/nex.md
@@ -2,21 +2,27 @@
 
 ### Requirements
 
-* Good range gear in range setup. Including a weapon (acb, dcb, zcb, tbow) and ammo (Dragon/rune arrows, or ruby dragon bolts (e)). Atleast 200 of the ammo youre using.
+* Level 90 Ranged, Level 90 Defence, Level 74 Prayer
+* Good range gear in range setup. Including a weapon (Armadyl Crossbow, Dragon Crossbow, Zaryte Crossbow, Twisted Bow) and ammo (Dragon/rune arrows, or Ruby Dragon Bolts (e)). Atleast 200 of the ammo youre using.
 * Supplies: 8 brews, 5 restores, 2 range pots, 1 sanfews, regardless of trip length/quantity.
-* 90 def, 90 ranged, 74 prayer
+
 
 ### Boosts & BIS
 
 * Rune arrows are negative/slower than dragon arrows.
-* ZCB is the best in slot weapon.
-* Zaryte vambs are BiS.
-* Rigour (dex scroll used) gives a boost.
-* If using an ely or spectral, your maximum trip length will be longer! This is a new mechanic not really used elsewhere. It means you can kill extra nex's per trip, because they let you sustain for longer. Note: The time is applied per user, e.g. maybe +3mins per user in the team, for the maximum increase, everyone in the team needs one.
-* Ely reduces death chance significantly.
+* Zaryte Crossbow is the best in weapon slot.
+* Zaryte vambraces are BIS in gloves slot.
+* Rigour (Dexterous Prayer Scroll used) gives a boost.
+* If using an ely or spectral, your maximum trip length will be longer! This is a new mechanic not really used elsewhere. It means you can kill extra nex's per trip, because they let you sustain for longer. Note: The time is applied per user, e.g. maybe +3 mins per user in the team, for the maximum increase, everyone in the team needs one.
+* Spectral has best mage defence bonus in the shield slot.
+* Ely reduces death chance by 30%.
 * You get faster at killing Nex based on your Offence% (gear) and your KC.
 
-Zcb/Ely, Acb/Ely, Acb/Spectral, Tbow. Best to worst\
+Zaryte Crossbow + Ely, Armadyl Crossbow + Ely, Armadyl Crossbow + Spectral, Twisted Bow (Best to worst)
 
+#### BIS Gear
+![BIS Gear](<https://user-images.githubusercontent.com/103688866/163592990-d21a8cd4-6ca3-421d-97b8-0e4b87840ab1.png>)
 
-![BIS without a Zaryte Crossbow](<../.gitbook/assets/image (17).png>)
+#### BIS Gear without Nex Items
+![BIS Gear](<https://user-images.githubusercontent.com/103688866/163593388-4f38af8f-d489-4b2a-b0fe-96b063cd9109.png>)
+


### PR DESCRIPTION
Re-arranged order the Requirements line
Changed some abbreviations to spell out full item names to avoid confusion

Added BIS Gear with Nex Items (image)
Added BIS Gear w/o Nex Items (image)
--Previously there was only "BIS Gear without ZCB" which was misleading as it didn't have Zaryte Vambraces in the referenced
Updated Elysian SS Bost information to show the specific death chance reduction (30%)
Updated wording to reflect Spectral SS having the best mage defence bonus in the shield slot